### PR TITLE
Support doctrine/orm 2.18 & 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "PHP Doctrine Extension that add window functions functionality ",
     "type": "package",
     "require": {
-        "doctrine/orm": "^2.7"
+        "doctrine/orm": "^2.14 || ^3.0",
+        "doctrine/lexer": "^2 || ^3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Query/Mysql/Window.php
+++ b/src/Query/Mysql/Window.php
@@ -28,7 +28,7 @@ class Window extends FunctionNode
 
         if ($lexer->isNextToken(Lexer::T_IDENTIFIER)) {
             $this->isNativeWindowFuction = true;
-            $this->nativeFunction = $lexer->lookahead['value'];
+            $this->nativeFunction = $lexer->lookahead->value;
             $parser->match(Lexer::T_IDENTIFIER); // to function name
             $parser->match(Lexer::T_OPEN_PARENTHESIS);
             if (!$lexer->isNextToken(Lexer::T_CLOSE_PARENTHESIS)) {
@@ -39,7 +39,7 @@ class Window extends FunctionNode
             $this->aggregateFunction = $parser->StringPrimary();
         }
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-        if ($lexer->isNextToken(Lexer::T_IDENTIFIER) && strtolower($lexer->lookahead['value']) === 'over') {
+        if ($lexer->isNextToken(Lexer::T_IDENTIFIER) && strtolower($lexer->lookahead->value) === 'over') {
             // $this->overPart = $parser->StringPrimary();
             $this->parseOver($parser);
         } else {
@@ -58,7 +58,7 @@ class Window extends FunctionNode
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
 
         $lexer = $parser->getLexer();
-        if($lexer->isNextToken(Lexer::T_IDENTIFIER)&&strtolower($lexer->lookahead['value'])==='partition'){
+        if($lexer->isNextToken(Lexer::T_IDENTIFIER)&&strtolower($lexer->lookahead->value)==='partition'){
             // $this->partitionByClause=true;
             $this->partitionByFields=$this->parseGrouping($parser,Lexer::T_IDENTIFIER);
         }


### PR DESCRIPTION
As these version (can) use doctrine/lexer:3.
The minimum version of orm support is elevated to 2.14, as prior version doesn't allow lexer>=2